### PR TITLE
fix: update core packages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -63,13 +63,8 @@ const LOCKFILE_TO_PACKAGE_MANAGER: Record<string, PackageManager> = {
 }
 // core-packages to be overridden
 const RSPACK_PACKAGES = [
-  '@rspack/binding',
   '@rspack/core',
   '@rspack/cli',
-  '@rspack/dev-server',
-  '@rspack/plugin-minify',
-  '@rspack/plugin-preact-refresh',
-  '@rspack/plugin-react-refresh',
 ]
 
 function getPackageJsonPath() {


### PR DESCRIPTION
- Many Rspack packages has been moved to separate repos.
- No need to override `@rspack/binding` as it is a sub-dependency.