### PR TITLE
chore(infra): enable npm trusted publishing and refactor release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,77 +1,47 @@
-name: Release Full
+# This action will publish the package to npm and create a GitHub release.
+name: Release
 
 on:
+  # Run `npm run bump` to bump the version and create a git tag.
+  push:
+    tags:
+      - 'v*'
+
   workflow_dispatch:
-    inputs:
-      version:
-        type: choice
-        description: "Release Version Type"
-        required: true
-        default: "patch"
-        options:
-          - major
-          - premajor
-          - minor
-          - preminor
-          - patch
-          - prepatch
-          - prerelease
-
-      tag:
-        type: choice
-        description: "Release Npm Tag"
-        required: true
-        default: "latest"
-        options:
-          - canary
-          - nightly
-          - latest
-          - beta
-          - alpha
-
-      dry_run:
-        type: boolean
-        description: "DryRun release"
-        required: true
-        default: false
 
 permissions:
-  # To publish packages with provenance
+  contents: write
   id-token: write
 
 jobs:
-  release:
-    name: Release
-    environment: production
-    permissions:
-      contents: write
-      # To publish packages with provenance
-      id-token: write
+  publish:
     runs-on: ubuntu-latest
-
+    environment: npm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Pnpm
-        run: corepack enable
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: "pnpm"
+          node-version: 22
+
+      - name: Setup Package Managers
+        run: |
+          npm install -g npm@latest
+          npm --version
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Install Dependencies
         run: pnpm install
 
-      # - name: Run Test
-      #   run: pnpm run test
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: empty
 
-      - name: Try release to npm
-        run: pnpm run release
-        env:
-          DRY_RUN: ${{ inputs.dry_run }}
-          TAG: ${{ inputs.tag }}
-          VERSION: ${{ inputs.version }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: 'true'

--- a/index.ts
+++ b/index.ts
@@ -211,7 +211,9 @@ function getOverrides(version: string): Record<string, string> {
       if (isSnapshot) {
         return [
           name,
-          `npm:${toCanaryPackageName(name)}${targetVersion ? `@${targetVersion}` : ''}`,
+          `npm:${toCanaryPackageName(name)}${
+            targetVersion ? `@${targetVersion}` : ''
+          }`,
         ]
       } else {
         return [name, `${targetVersion}`]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prepare": "pnpm run build",
     "build": "node ./build.js",
     "release": "node ./scripts/release.mjs",
-    "format": "prettier ./index.ts --write"
+    "format": "prettier ./index.ts --write",
+    "bump": "npx bumpp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers